### PR TITLE
Fix command yarn run start

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "build:gh": "gatsby build --prefix-paths",
     "dev": "gatsby develop",
     "format": "prettier --write src/**/*.{js,jsx}",
-    "start": "yarn run develop",
+    "start": "yarn run dev",
     "serve": "gatsby serve",
     "eslint": "eslint .",
     "jest": "jest",


### PR DESCRIPTION
```
yarn start
yarn run v1.17.3
$ yarn run develop
error Command "develop" not found.
```